### PR TITLE
Honor hydrogen isotopes in ElementProvider

### DIFF
--- a/singa-chemistry/src/main/java/bio/singa/chemistry/model/elements/Element.java
+++ b/singa-chemistry/src/main/java/bio/singa/chemistry/model/elements/Element.java
@@ -315,6 +315,7 @@ public class Element {
 
         Element element = (Element) o;
 
+        if (!symbol.equals(element.symbol)) return false;
         if (protonNumber != element.protonNumber) return false;
         if (electronNumber != element.electronNumber) return false;
         return neutronNumber == element.neutronNumber;
@@ -322,7 +323,8 @@ public class Element {
 
     @Override
     public int hashCode() {
-        int result = protonNumber;
+        int result = symbol.hashCode();
+        result = 31 * result + protonNumber;
         result = 31 * result + electronNumber;
         result = 31 * result + neutronNumber;
         return result;

--- a/singa-chemistry/src/main/java/bio/singa/chemistry/model/elements/ElementProvider.java
+++ b/singa-chemistry/src/main/java/bio/singa/chemistry/model/elements/ElementProvider.java
@@ -1,9 +1,6 @@
 package bio.singa.chemistry.model.elements;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 /**
  * This library provides Elements 1 (Hydrogen) to 111 (Roentgenium) with their names, symbols, atomic numbers, and
@@ -128,7 +125,7 @@ public final class ElementProvider {
 
     public static final Element UNKOWN = addElement(new Element("Unkown", "X", 0, 0, "1s0"));
 
-    private final Set<Element> elements = new HashSet<>();
+    private final Set<Element> elements = new LinkedHashSet<>();
 
     private static Element addElement(Element element) {
         INSTANCE.elements.add(element);

--- a/singa-structure/src/test/java/bio/singa/structure/io/pdb/structures/StructureWriterTest.java
+++ b/singa-structure/src/test/java/bio/singa/structure/io/pdb/structures/StructureWriterTest.java
@@ -314,4 +314,23 @@ class StructureWriterTest {
         long renumberedConectCount = renumberedPdbContent.stream().filter(l -> l.startsWith(CONECT_RECORD)).count();
         assertEquals(expectedRecordCount, renumberedConectCount, "number of CONECT records should be unchanged even if renumbered");
     }
+
+    @Test
+    void shouldWriteDeuterium() {
+        String pdbIdentifier = "5e5k";
+
+        Structure structure = StructureParser.cif()
+                .pdbIdentifier(pdbIdentifier)
+                .parse();
+
+        List<String> pdbContent = Arrays.stream(StructureWriter.pdb()
+                .structure(structure)
+                .settings(APPEND_ALL_LIGAND_CONNECTIONS)
+                .writeToString()
+                .split("\n"))
+                .collect(Collectors.toList());
+
+        assertTrue(pdbContent.stream().anyMatch(l -> l.endsWith("D  ")), "should write deuterium");
+        assertTrue(pdbContent.stream().noneMatch(l -> l.endsWith("X  ")), "shouldn't write unknown element");
+    }
 }


### PR DESCRIPTION
This ensures that deuterium atoms (e.g. from 5e5k) are tagged with the proper element when exporting .pdb files, rather than using the `X` fallback that causes issues when parsing the file again.