### PR TITLE
Detect long serial numbers and try to renumber them when exporting .pdb files

### DIFF
--- a/singa-structure/src/main/java/bio/singa/structure/io/general/StructureRenumberer.java
+++ b/singa-structure/src/main/java/bio/singa/structure/io/general/StructureRenumberer.java
@@ -30,7 +30,6 @@ public class StructureRenumberer {
     /**
      * Renumbers the {@link LeafSubstructure}s in a given {@link PdbStructure} according to a renumbering map.
      * <b>Warning:</b>The method copies only the parts of the structure which are covered by the renumbering map.
-     * Non-consecutive parts of the structure (ligands, etc.) are not affected and copied to the new structure.
      *
      * @param structure The {@link PdbStructure} to be renumbered.
      * @param renumberingMap The renumbering map, containing as key original {@link LeafIdentifier}s the renumbered
@@ -40,7 +39,6 @@ public class StructureRenumberer {
     public static Structure renumberLeaveSubstructuresWithMap(Structure structure, Map<AuthLeafIdentifier, Integer> renumberingMap) {
         StructureRenumberer structureRenumberer = new StructureRenumberer();
         return structureRenumberer.renumberLeafSubstructures(((PdbStructure) structure), renumberingMap);
-
     }
 
     public static Structure renumberEverything(Structure structure) {
@@ -299,15 +297,31 @@ public class StructureRenumberer {
                     copyAtomsInLeafSubstructure(leafSubstructure, renumberedLeafSubstructure);
                 }
             }
-            // nonconsecutive parts are copied without renumbering
+            // nonconsecutive parts
             for (Chain chain : model.getAllChains()) {
                 PdbChain oakChain = (PdbChain) chain;
                 PdbChain renumberedChain = renumberedModel.getChain(chain.getChainIdentifier()).orElseThrow(NoSuchElementException::new);
                 for (PdbLeafSubstructure leafSubstructure : oakChain.getNonConsecutivePart()) {
-                    PdbLeafSubstructure renumberedLeafSubstructure = createLeafSubstructure(leafSubstructure.getIdentifier(), leafSubstructure.getFamily());
-                    renumberedLeafSubstructure.setAnnotatedAsHeteroAtom(true);
-                    renumberedChain.addLeafSubstructure(renumberedLeafSubstructure);
-                    copyAtomsInLeafSubstructure(leafSubstructure, renumberedLeafSubstructure);
+                    AuthLeafIdentifier originalIdentifier = leafSubstructure.getIdentifier();
+                    // for non-consecutive, we remap or copy everything
+                    if (renumberingMap.containsKey(originalIdentifier)) {
+                        AuthLeafIdentifier renumberedIdentifier = new AuthLeafIdentifier(
+                                originalIdentifier.getStructureIdentifier(),
+                                originalIdentifier.getModelIdentifier(),
+                                originalIdentifier.getChainIdentifier(),
+                                renumberingMap.get(originalIdentifier),
+                                originalIdentifier.getInsertionCode());
+                        PdbLeafSubstructure renumberedLeafSubstructure = createLeafSubstructure(renumberedIdentifier, leafSubstructure.getFamily());
+                        renumberedLeafSubstructure.setAnnotatedAsHeteroAtom(leafSubstructure.isAnnotatedAsHeteroAtom());
+                        renumberedChain.addLeafSubstructure(renumberedLeafSubstructure, false);
+                        copyAtomsInLeafSubstructure(leafSubstructure, renumberedLeafSubstructure);
+                    } else {
+                        //  copied without renumbering
+                        PdbLeafSubstructure renumberedLeafSubstructure = createLeafSubstructure(leafSubstructure.getIdentifier(), leafSubstructure.getFamily());
+                        renumberedLeafSubstructure.setAnnotatedAsHeteroAtom(true);
+                        renumberedChain.addLeafSubstructure(renumberedLeafSubstructure);
+                        copyAtomsInLeafSubstructure(leafSubstructure, renumberedLeafSubstructure);
+                    }
                 }
             }
         }

--- a/singa-structure/src/main/java/bio/singa/structure/io/general/StructureRepresentationFactory.java
+++ b/singa-structure/src/main/java/bio/singa/structure/io/general/StructureRepresentationFactory.java
@@ -7,7 +7,6 @@ import bio.singa.structure.model.interfaces.LeafSubstructure;
 import bio.singa.structure.model.interfaces.Model;
 import bio.singa.structure.model.interfaces.Structure;
 import bio.singa.structure.model.pdb.*;
-import uk.ac.ebi.beam.Bond;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,7 +43,7 @@ public class StructureRepresentationFactory {
         this.structure = structure;
         StringBuilder sb = new StringBuilder();
         // add preamble
-        sb.append(getPreamble(structure.getStructureIdentifier(), structure.getTitle(), determineLinkEntries(structure)));
+        sb.append(getPreamble());
         // get all models
         List<Integer> modelIdentifiers = structure.getAllModels().stream()
                 .map(Model::getModelIdentifier)
@@ -67,13 +66,13 @@ public class StructureRepresentationFactory {
             }
         }
         // add postamble
-        sb.append(getPostamble(structure.getAllLeafSubstructures()));
+        sb.append(getPostamble());
         return sb.toString();
     }
 
     private List<LinkEntry> determineLinkEntries(Structure structure) {
         if (structure instanceof PdbStructure) {
-            return ((PdbStructure) structure).getLinkEntries();
+            return structure.getLinkEntries();
         }
         return Collections.emptyList();
     }
@@ -141,7 +140,10 @@ public class StructureRepresentationFactory {
      *
      * @return The title and header line for this structure.
      */
-    private String getPreamble(String pdbIdentifier, String title, List<LinkEntry> linkEntries) {
+    private String getPreamble() {
+        String pdbIdentifier = structure.getStructureIdentifier();
+        String title = structure.getTitle();
+
         StringBuilder sb = new StringBuilder();
         // header
         if (pdbIdentifier != null && !pdbIdentifier.equals(LeafIdentifier.DEFAULT_PDB_IDENTIFIER)) {
@@ -177,8 +179,13 @@ public class StructureRepresentationFactory {
                     .forEach(sb::append);
         }
 
+        // track original residue numbers of those that have been renumbered
+        if (options.isAddRenumberedLeafs()) {
+            sb.append(Remark951Token.assemblePDBLines(options.getRenumberingMap()));
+        }
+
         // links
-        for (LinkEntry linkEntry : linkEntries) {
+        for (LinkEntry linkEntry : determineLinkEntries(structure)) {
             sb.append(LinkToken.assemblePDBLine(linkEntry));
         }
         return sb.toString();
@@ -194,10 +201,10 @@ public class StructureRepresentationFactory {
      *
      * @return The closing lines.
      */
-    private String getPostamble(Collection<? extends LeafSubstructure> leafSubstructures) {
+    private String getPostamble() {
         String connectRecords = "";
         if (options.isAddConnections()) {
-            connectRecords = leafSubstructures.stream()
+            connectRecords = structure.getAllLeafSubstructures().stream()
                     .map(PdbLeafSubstructure.class::cast)
                     .filter(PdbLeafSubstructure::isAnnotatedAsHeteroAtom) // TODO this omits inter-molecule connections for polymeric components (e.g. disulfide bridges), ideally these would be included
                     .map(ConnectionToken::assemblePDBLines)

--- a/singa-structure/src/main/java/bio/singa/structure/io/general/StructureRepresentationOptions.java
+++ b/singa-structure/src/main/java/bio/singa/structure/io/general/StructureRepresentationOptions.java
@@ -17,6 +17,7 @@ public class StructureRepresentationOptions {
      * Happening when 5-character ligands from mmCIF are renamed for compatibility.
      */
     private boolean addRenamedLigands = true;
+    private boolean addRenumberedLeafs = true;
 
     private Map<AuthLeafIdentifier, Integer> renumberingMap;
 
@@ -104,6 +105,14 @@ public class StructureRepresentationOptions {
         this.addRenamedLigands = addRenamedLigands;
     }
 
+    public boolean isAddRenumberedLeafs() {
+        return addRenumberedLeafs;
+    }
+
+    public void setAddRenumberedLeafs(boolean addRenumberedLeafs) {
+        this.addRenumberedLeafs = addRenumberedLeafs;
+    }
+
     /**
      * Sets the any option.
      *
@@ -148,6 +157,12 @@ public class StructureRepresentationOptions {
             case OMIT_RENAMED_LIGANDS:
                 options.addRenamedLigands = false;
                 break;
+            case APPEND_RENUMBERED_LEAFS:
+                options.addRenumberedLeafs = true;
+                break;
+            case OMIT_RENUMBERED_LEAFS:
+                options.addRenumberedLeafs = false;
+                break;
         }
     }
 
@@ -183,6 +198,17 @@ public class StructureRepresentationOptions {
          * Always suppress the REMARK 950 record.
          */
         OMIT_RENAMED_LIGANDS,
+
+        /**
+         * Write a dedicated REMARK 951 record if residues have been renumbered. This record will hold the original leaf
+         * identifier.
+         */
+        APPEND_RENUMBERED_LEAFS,
+
+        /**
+         * Always suppress the REMARK 951 record.
+         */
+        OMIT_RENUMBERED_LEAFS,
     }
 
 }

--- a/singa-structure/src/main/java/bio/singa/structure/io/general/StructureWriter.java
+++ b/singa-structure/src/main/java/bio/singa/structure/io/general/StructureWriter.java
@@ -207,14 +207,14 @@ public class StructureWriter {
             }
 
             // check for residue numbers >9999 that can be renumbered (like waters in 5t1s)
-            conditionallyRenumberResidues();
+            conditionallyRequestResiduesRenumbering();
 
             if (options.isRenumberingSubstructures()) {
                 structure = StructureRenumberer.renumberLeaveSubstructuresWithMap(structure, options.getRenumberingMap());
             }
         }
 
-        private void conditionallyRenumberResidues() {
+        private void conditionallyRequestResiduesRenumbering() {
             // nop if explicitly provided
             if (options.isRenumberingSubstructures() && !options.getRenumberingMap().isEmpty()) return;
 

--- a/singa-structure/src/main/java/bio/singa/structure/io/general/StructureWriter.java
+++ b/singa-structure/src/main/java/bio/singa/structure/io/general/StructureWriter.java
@@ -3,21 +3,27 @@ package bio.singa.structure.io.general;
 import bio.singa.structure.model.cif.CifStructure;
 import bio.singa.structure.model.interfaces.*;
 import bio.singa.structure.model.general.LinkEntry;
-import bio.singa.structure.model.pdb.PdbStructure;
 import bio.singa.structure.model.general.AuthLeafIdentifier;
 import bio.singa.structure.model.general.Structures;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class StructureWriter {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     // TODO option for short and long ter records
 
@@ -185,7 +191,7 @@ public class StructureWriter {
                 structure = Structures.toStructure(leafSubstructures, pdbIdentifier, title);
             }
             if (linkEntries != null) {
-                linkEntries.forEach(linkEntry -> ((PdbStructure) structure).addLinkEntry(linkEntry));
+                linkEntries.forEach(linkEntry -> structure.addLinkEntry(linkEntry));
             }
             // apply renumbering
             if (structure != null && structure instanceof CifStructure) {
@@ -199,8 +205,42 @@ public class StructureWriter {
             if (options.isRenumberingAtoms()) {
                 structure = StructureRenumberer.renumberAtomsConsecutively(structure, options.isRenumberChains());
             }
+
+            // check for residue numbers >9999 that can be renumbered (like waters in 5t1s)
+            conditionallyRenumberResidues();
+
             if (options.isRenumberingSubstructures()) {
                 structure = StructureRenumberer.renumberLeaveSubstructuresWithMap(structure, options.getRenumberingMap());
+            }
+        }
+
+        private void conditionallyRenumberResidues() {
+            // nop if explicitly provided
+            if (options.isRenumberingSubstructures() && !options.getRenumberingMap().isEmpty()) return;
+
+            Set<String> chainsNeedingRenumber = structure.getAllLeafSubstructures().stream()
+                    .filter(l -> l.getIdentifier().getSerial() > 9999)
+                    .map(l -> l.getAuthIdentifier().getChainIdentifier())
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            if (!chainsNeedingRenumber.isEmpty()) {
+                logger.warn("{} has residue serials >9999, trying to renumber leafs in chains {}", structure.getStructureIdentifier(), chainsNeedingRenumber);
+
+                Map<AuthLeafIdentifier, Integer> renumbering = new LinkedHashMap<>();
+                options.setRenumberingSubstructures(true);
+                options.setRenumberingMap(renumbering);
+
+                // track assigned serials within each chain
+                Map<String, AtomicInteger> perChainSerials = chainsNeedingRenumber.stream().collect(Collectors.toMap(Function.identity(), __ -> new AtomicInteger()));
+                for (LeafSubstructure leaf : structure.getAllLeafSubstructures()) {
+                    String chainIdentifier = leaf.getAuthIdentifier().getChainIdentifier();
+                    if (!chainsNeedingRenumber.contains(chainIdentifier)) continue;
+
+                    int serial = perChainSerials.get(chainIdentifier).incrementAndGet();
+                    renumbering.put(leaf.getAuthIdentifier(), serial);
+                    if (serial > 9999) {
+                        throw new IllegalStateException("More than 9999 residues in chain " + chainIdentifier + " -- can't represent in PDB format");
+                    }
+                }
             }
         }
 

--- a/singa-structure/src/main/java/bio/singa/structure/io/pdb/tokens/AtomToken.java
+++ b/singa-structure/src/main/java/bio/singa/structure/io/pdb/tokens/AtomToken.java
@@ -8,7 +8,10 @@ import bio.singa.structure.model.interfaces.Atom;
 import bio.singa.structure.model.interfaces.LeafSubstructure;
 import bio.singa.structure.model.pdb.PdbAtom;
 import bio.singa.structure.model.general.AuthLeafIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
@@ -37,6 +40,7 @@ public enum AtomToken implements PDBToken {
     ELEMENT_SYMBOL(Range.of(77, 78), Justification.RIGHT),
     ELEMENT_CHARGE(Range.of(79, 80), Justification.LEFT);
 
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getSimpleName());
     public static final Pattern RECORD_PATTERN = Pattern.compile("^(ATOM|HETATM).*");
 
     private static final DecimalFormat coordinateFormat = new DecimalFormat("0.000", new DecimalFormatSymbols(Locale.US));
@@ -153,6 +157,10 @@ public enum AtomToken implements PDBToken {
 
     private String createTokenString(String content) {
         int totalLength = columns.getUpperBound() - columns.getLowerBound() - content.length();
+        // -1 is fine-ish as this cuts into empty columns
+        if (totalLength < -1) {
+            logger.warn("overflowing {} content: '{}', max length [{}, {}]", this, content, columns.getLowerBound(), columns.getUpperBound());
+        }
         StringBuilder filler = new StringBuilder();
         for (int i = 0; i < totalLength + 1; i++) {
             filler.append(" ");
@@ -162,5 +170,4 @@ public enum AtomToken implements PDBToken {
         }
         return filler + content;
     }
-
 }

--- a/singa-structure/src/main/java/bio/singa/structure/io/pdb/tokens/AtomToken.java
+++ b/singa-structure/src/main/java/bio/singa/structure/io/pdb/tokens/AtomToken.java
@@ -40,7 +40,7 @@ public enum AtomToken implements PDBToken {
     ELEMENT_SYMBOL(Range.of(77, 78), Justification.RIGHT),
     ELEMENT_CHARGE(Range.of(79, 80), Justification.LEFT);
 
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getSimpleName());
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     public static final Pattern RECORD_PATTERN = Pattern.compile("^(ATOM|HETATM).*");
 
     private static final DecimalFormat coordinateFormat = new DecimalFormat("0.000", new DecimalFormatSymbols(Locale.US));

--- a/singa-structure/src/main/java/bio/singa/structure/io/pdb/tokens/Remark951Token.java
+++ b/singa-structure/src/main/java/bio/singa/structure/io/pdb/tokens/Remark951Token.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
  * SiNGA will use this remark to track 5-character residue serials encountered while parsing mmCIF content. This remark
  * provides the original identifier for downstream scripts.
  *
- * this should be compliant with pdb standards as long serials in a chain are don't exceed 9999
+ * this should be compliant with pdb standards as long serials in a chain don't exceed 9999
  *
  * Example
  * REMARK 951
@@ -52,7 +52,7 @@ public enum Remark951Token implements PDBToken {
             return "";
         }
         StringBuilder sb = new StringBuilder();
-        // REMARK 951 A1IYK renamed to LIG
+        // REMARK 951 5t1s-1-D-10001 renamed to 5t1s-1-D-286
         for (Map.Entry<AuthLeafIdentifier, Integer> entry : mapping.entrySet()) {
             String full = entry.getKey().toString();
             int lastDash = full.lastIndexOf('-');

--- a/singa-structure/src/main/java/bio/singa/structure/io/pdb/tokens/Remark951Token.java
+++ b/singa-structure/src/main/java/bio/singa/structure/io/pdb/tokens/Remark951Token.java
@@ -1,0 +1,69 @@
+package bio.singa.structure.io.pdb.tokens;
+
+import bio.singa.core.utility.Range;
+import bio.singa.structure.io.general.StructureRepresentationFactory;
+import bio.singa.structure.model.general.AuthLeafIdentifier;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * SiNGA will use this remark to track 5-character residue serials encountered while parsing mmCIF content. This remark
+ * provides the original identifier for downstream scripts.
+ *
+ * this should be compliant with pdb standards as long serials in a chain are don't exceed 9999
+ *
+ * Example
+ * REMARK 951
+ * REMARK 951 A1IYK renamed to LIG
+ * REMARK 951
+ *
+ * @author sb
+ */
+public enum Remark951Token implements PDBToken {
+
+    RECORD_TYPE(Range.of(1, 6)),
+    REMARK_NUMBER(Range.of(8, 10)),
+    REMARK_CONTENT(Range.of(12, 79));
+
+    public static final Pattern RECORD_PATTERN = Pattern.compile("^(REMARK).*");
+    public static final Pattern REMARK_951 = Pattern.compile("^REMARK 951.*");
+    private static final String PREFIX = "REMARK 951";
+    public static final String SEPARATOR = " renamed to ";
+
+    private final Range<Integer> columns;
+
+    Remark951Token(Range<Integer> columns) {
+        this.columns = columns;
+    }
+
+    @Override
+    public Range<Integer> getColumns() {
+        return columns;
+    }
+
+    @Override
+    public Pattern getRecordNamePattern() {
+        return RECORD_PATTERN;
+    }
+
+    public static String assemblePDBLines(Map<AuthLeafIdentifier, Integer> mapping) {
+        if (mapping == null || mapping.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        // REMARK 951 A1IYK renamed to LIG
+        for (Map.Entry<AuthLeafIdentifier, Integer> entry : mapping.entrySet()) {
+            String full = entry.getKey().toString();
+            int lastDash = full.lastIndexOf('-');
+            String replaced = full.substring(0, lastDash + 1) + entry.getValue();
+
+            sb.append(PREFIX).append(" ")
+                    .append(full)
+                    .append(SEPARATOR)
+                    .append(replaced)
+                    .append(System.lineSeparator());
+        }
+        return sb.toString();
+    }
+}

--- a/singa-structure/src/test/java/bio/singa/structure/io/pdb/structures/StructureWriterTest.java
+++ b/singa-structure/src/test/java/bio/singa/structure/io/pdb/structures/StructureWriterTest.java
@@ -314,4 +314,26 @@ class StructureWriterTest {
         long renumberedConectCount = renumberedPdbContent.stream().filter(l -> l.startsWith(CONECT_RECORD)).count();
         assertEquals(expectedRecordCount, renumberedConectCount, "number of CONECT records should be unchanged even if renumbered");
     }
+
+    @Test
+    void shouldWriteValidPdbFileWithLongIdentifiers() {
+        String pdbIdentifier = "5T1S";
+
+        System.out.println("parsing original CIF");
+        Structure structure = StructureParser.cif()
+                .pdbIdentifier(pdbIdentifier)
+                .parse();
+
+        System.out.println("writing structure (with implicit renumbering)");
+        List<String> implicitlyRenumbered = Arrays.stream(StructureWriter.pdb()
+                        .structure(structure)
+                        .settings() // should auto-detect that residue-renumbering is required
+                        .writeToString()
+                        .split("\n"))
+                .collect(Collectors.toList());
+        for (String line : implicitlyRenumbered) {
+            assertTrue(line.length() <= 80, "malformed PDB line with length " + line.length() + ": " + line);
+        }
+        assertTrue(implicitlyRenumbered.stream().anyMatch(line -> line.startsWith("REMARK 951")), "expected dedicated REMARK 951 record that tracks residue renumbering");
+    }
 }

--- a/singa-structure/src/test/java/bio/singa/structure/io/pdb/structures/StructureWriterTest.java
+++ b/singa-structure/src/test/java/bio/singa/structure/io/pdb/structures/StructureWriterTest.java
@@ -346,6 +346,6 @@ class StructureWriterTest {
         for (String line : explicitlyRenumbered) {
             assertTrue(line.length() <= 80, "malformed PDB line with length " + line.length() + ": " + line);
         }
-        assertTrue(explicitlyRenumbered.stream().anyMatch(line -> line.startsWith("REMARK 951")), "expected dedicated REMARK 951 record that tracks residue renumbering");
+        assertFalse(explicitlyRenumbered.stream().anyMatch(line -> line.startsWith("REMARK 951")), "no dedicated REMARK 951 record to be written when renumbering everything");
     }
 }

--- a/singa-structure/src/test/java/bio/singa/structure/io/pdb/structures/StructureWriterTest.java
+++ b/singa-structure/src/test/java/bio/singa/structure/io/pdb/structures/StructureWriterTest.java
@@ -335,5 +335,17 @@ class StructureWriterTest {
             assertTrue(line.length() <= 80, "malformed PDB line with length " + line.length() + ": " + line);
         }
         assertTrue(implicitlyRenumbered.stream().anyMatch(line -> line.startsWith("REMARK 951")), "expected dedicated REMARK 951 record that tracks residue renumbering");
+
+        System.out.println("writing structure (by requesting renumbering)");
+        List<String> explicitlyRenumbered = Arrays.stream(StructureWriter.pdb()
+                        .structure(structure)
+                        .settings(RENUMBER_SUBSTRUCTURES, RENUMBER_ATOMS_CONSECUTIVELY, RENUMBER_CHAINS_CONSECUTIVELY) // shortcut that renumbers even without provided residue mapping
+                        .writeToString()
+                        .split("\n"))
+                .collect(Collectors.toList());
+        for (String line : explicitlyRenumbered) {
+            assertTrue(line.length() <= 80, "malformed PDB line with length " + line.length() + ": " + line);
+        }
+        assertTrue(explicitlyRenumbered.stream().anyMatch(line -> line.startsWith("REMARK 951")), "expected dedicated REMARK 951 record that tracks residue renumbering");
     }
 }


### PR DESCRIPTION
- renumbers comically long serials when exporting .pdb files (e.g., for [5T1S](https://www.rcsb.org/3d-view/5T1S?preset=ligandInteraction&label_comp_id=HOH))
- non-consecutive leafs (ligands/ions/waters/...) will now be propagated when remapping a structure
- tracks renumbered content in dedicated REMARK 951 lines by default
- a dedicated `StructureWriter` options allows omitting this information